### PR TITLE
added bwa

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -286,6 +286,7 @@ let
      
   system_packages = builtins.attrValues {
     inherit (pkgs) 
+      bwa
       glibcLocales
       nix
       R;


### PR DESCRIPTION
This change adds bwa to the environment.

In the call to `renv2nix()`, you can add `bwa` to the `system_pkgs`: `renv2nix("renv.lock", system_pkgs = "bwa")` to add the package. Because `bwa` is already packages for Nix, you don’t need to build it yourself.